### PR TITLE
修复写EsWriter线程不结束的bug

### DIFF
--- a/mr/src/main/java/com/didichuxing/datachannel/arius/fastindex/es/EsWriter.java
+++ b/mr/src/main/java/com/didichuxing/datachannel/arius/fastindex/es/EsWriter.java
@@ -12,7 +12,7 @@ public class EsWriter {
     private Integer batchSize = 500;        // 单次写入的数据个数
     private Integer threadPoolSize = 4;     // 线程个数
     private List<ESClient.IndexNode> nodeList = new ArrayList<>();  // 当前缓存的ES数据
-    private boolean isStop = false;
+    private volatile boolean isStop = false;
     private Object lock = new Object();
     private List<Thread> threadPool = new ArrayList<>();
 


### PR DESCRIPTION
isStop有可见性问题，写es的线程是非守护线程，当写es的线程对isStop的变化不可见时会出现进程卡住不退出的情况